### PR TITLE
Prevent DOMException upon unmounting component that is not mounted yet

### DIFF
--- a/src/mount.js
+++ b/src/mount.js
@@ -42,9 +42,11 @@ export const unmount = (parent, child) => {
     child = childEl.__redom_view;
   }
 
-  doUnmount(child, childEl, parentEl);
+  if (parentEl.contains(childEl) === true) {
+    doUnmount(child, childEl, parentEl);
 
-  parentEl.removeChild(childEl);
+    parentEl.removeChild(childEl);
+  }
 
   return child;
 };

--- a/test/redom.js
+++ b/test/redom.js
@@ -114,9 +114,11 @@ var unmount = function (parent, child) {
     child = childEl.__redom_view;
   }
 
-  doUnmount(child, childEl, parentEl);
+  if (parentEl.contains(childEl) === true) {
+    doUnmount(child, childEl, parentEl);
 
-  parentEl.removeChild(childEl);
+    parentEl.removeChild(childEl);
+  }
 
   return child;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -442,6 +442,18 @@ module.exports = function (redom) {
       mount(document.body, table);
       t.equals(document.body.innerHTML, '<table><tr><td>1</td><td>2</td><td>3</td></tr></table>');
     });
+    t.test('unmounting unmounted', function (t) {
+      t.plan(2);
+      function Test () {
+        this.el = el('div');
+      }
+      var test = new Test();
+      unmount(document.body, test);
+      mount(document.body, test);
+      t.equals(document.body.contains(test.el), true);
+      unmount(document.body, test);
+      t.equals(document.body.contains(test.el), false);
+    });
   });
 
   test('SVG', function (t) {


### PR DESCRIPTION
Fix for #90 

Check if `parentEl` contains `childEl` before trying to remove it. Also skips lifecycle hooks if child is not found from DOM.