### PR TITLE
Use substrings in query parsing

### DIFF
--- a/src/parse-query.js
+++ b/src/parse-query.js
@@ -10,7 +10,7 @@ export const parseQuery = (query) => {
   let id = null;
   let className = null;
   let mode = TAG_NAME;
-  let buffer = '';
+  let offset = 0;
 
   for (let i = 0; i <= query.length; i++) {
     const char = query.charCodeAt(i);
@@ -23,15 +23,15 @@ export const parseQuery = (query) => {
         if (i === 0) {
           tag = 'div';
         } else {
-          tag = buffer;
+          tag = query.substring(offset, i);
         }
       } else if (mode === ID) {
-        id = buffer;
+        id = query.substring(offset, i);
       } else {
         if (className) {
-          className += ' ' + buffer;
+          className += ' ' + query.substring(offset, i);
         } else {
-          className = buffer;
+          className = query.substring(offset, i);
         }
       }
 
@@ -41,9 +41,7 @@ export const parseQuery = (query) => {
         mode = CLASS_NAME;
       }
 
-      buffer = '';
-    } else {
-      buffer += query[i];
+      offset = i + 1;
     }
   }
 

--- a/test/redom.js
+++ b/test/redom.js
@@ -14,7 +14,7 @@ var parseQuery = function (query) {
   var id = null;
   var className = null;
   var mode = TAG_NAME;
-  var buffer = '';
+  var offset = 0;
 
   for (var i = 0; i <= query.length; i++) {
     var char = query.charCodeAt(i);
@@ -27,15 +27,15 @@ var parseQuery = function (query) {
         if (i === 0) {
           tag = 'div';
         } else {
-          tag = buffer;
+          tag = query.substring(offset, i);
         }
       } else if (mode === ID) {
-        id = buffer;
+        id = query.substring(offset, i);
       } else {
         if (className) {
-          className += ' ' + buffer;
+          className += ' ' + query.substring(offset, i);
         } else {
-          className = buffer;
+          className = query.substring(offset, i);
         }
       }
 
@@ -45,9 +45,7 @@ var parseQuery = function (query) {
         mode = CLASS_NAME;
       }
 
-      buffer = '';
-    } else {
-      buffer += query[i];
+      offset = i + 1;
     }
   }
 


### PR DESCRIPTION
Instead of constructing separate buffer string, use substrings from original query string in `parseQuery` function. This could hopefully improve performance of the function.