### PR TITLE
Ensure lifecycle events are updated correctly during unmount triggered by setChildren

### DIFF
--- a/esm/unmount.js
+++ b/esm/unmount.js
@@ -35,18 +35,14 @@ export const doUnmount = (child, childEl, parentEl) => {
 
   while (traverse) {
     const parentHooks = traverse.__redom_lifecycle || {};
-    let hooksFound = false;
 
     for (const hook in hooks) {
       if (parentHooks[hook]) {
         parentHooks[hook] -= hooks[hook];
       }
-      if (parentHooks[hook]) {
-        hooksFound = true;
-      }
     }
 
-    if (!hooksFound) {
+    if (hooksAreEmpty(parentHooks)) {
       traverse.__redom_lifecycle = null;
     }
 

--- a/esm/unmount.js
+++ b/esm/unmount.js
@@ -22,7 +22,7 @@ export const unmount = (parent, child) => {
 export const doUnmount = (child, childEl, parentEl) => {
   const hooks = childEl.__redom_lifecycle;
 
-  if (!hooks) {
+  if (hooksAreEmpty(hooks)) {
     childEl.__redom_mounted = false;
     return;
   }
@@ -34,7 +34,7 @@ export const doUnmount = (child, childEl, parentEl) => {
   }
 
   while (traverse) {
-    const parentHooks = traverse.__redom_lifecycle || (traverse.__redom_lifecycle = {});
+    const parentHooks = traverse.__redom_lifecycle || {};
     let hooksFound = false;
 
     for (const hook in hooks) {
@@ -52,4 +52,8 @@ export const doUnmount = (child, childEl, parentEl) => {
 
     traverse = traverse.parentNode;
   }
+};
+
+const hooksAreEmpty = (hooks) => {
+  return !hooks || !Object.keys(hooks).filter(hook => hooks[hook]).length;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -232,6 +232,32 @@ module.exports = function (redom) {
         onunmount: true
       });
     });
+    t.test('lifecycle events on component when child unmounted using setChildren', function (t) {
+      t.plan(1);
+      var eventsFired = {
+        onmount: 0,
+        onunmount: 0
+      };
+      function Item () {
+        this.el = el('p');
+        this.onmount = function () {
+          eventsFired.onmount++;
+        };
+        this.onunmount = function () {
+          eventsFired.onunmount++;
+        };
+      }
+      var item = new Item();
+      var item2 = new Item();
+      mount(document.body, item);
+      setChildren(item.el, [ el('p') ]);
+      setChildren(item.el, [ item2 ]);
+      unmount(document.body, item);
+      t.deepEqual(eventsFired, {
+        onmount: 2,
+        onunmount: 2
+      });
+    });
     t.test('setChildren', function (t) {
       t.plan(4);
       var h1 = el.extend('h1');
@@ -803,5 +829,28 @@ module.exports = function (redom) {
 
     t.equals(a.el.innerHTML, '');
     unmount(document.body, a);
+  });
+
+  test('component moved below non-redom element', function (t) {
+    t.plan(3);
+    var div = document.createElement('div');
+    document.body.appendChild(div);
+    var targetDiv = document.createElement('div');
+    document.body.appendChild(targetDiv);
+
+    function Item() {
+      this.el = el('p');
+      this.onmount = function () {};
+    }
+
+    var item = new Item();
+    mount(div, item);
+    t.deepEquals(div.__redom_lifecycle, { onmount: 1 });
+    
+    targetDiv.appendChild(div);
+    t.strictEquals(targetDiv.__redom_lifecycle, undefined);
+
+    unmount(div, item);
+    t.strictEquals(targetDiv.__redom_lifecycle, null);
   });
 };

--- a/test/test.js
+++ b/test/test.js
@@ -868,7 +868,7 @@ module.exports = function (redom) {
     var targetDiv = document.createElement('div');
     document.body.appendChild(targetDiv);
 
-    function Item() {
+    function Item () {
       this.el = el('p');
       this.onmount = function () {};
     }
@@ -876,7 +876,7 @@ module.exports = function (redom) {
     var item = new Item();
     mount(div, item);
     t.deepEquals(div.__redom_lifecycle, { onmount: 1 });
-    
+
     targetDiv.appendChild(div);
     t.strictEquals(targetDiv.__redom_lifecycle, undefined);
 

--- a/test/test.js
+++ b/test/test.js
@@ -258,6 +258,36 @@ module.exports = function (redom) {
         onunmount: 2
       });
     });
+    t.test('lifecycle events on component when child with hooks unmounted using setChildren', function (t) {
+      t.plan(1);
+      var eventsFired = {
+        onmount: 0,
+        onunmount: 0
+      };
+      function MountHook () {
+        this.el = el('p');
+        this.onmount = function () {
+          eventsFired.onmount++;
+        };
+      }
+      function UnmountHook () {
+        this.el = el('p');
+        this.onunmount = function () {
+          eventsFired.onunmount++;
+        };
+      }
+      var mh = new MountHook();
+      var uh = new UnmountHook();
+      var uh2 = new UnmountHook();
+      mount(document.body, uh);
+      setChildren(uh.el, [ mh ]);
+      setChildren(uh.el, [ uh2 ]);
+      unmount(document.body, uh);
+      t.deepEqual(eventsFired, {
+        onmount: 1,
+        onunmount: 2
+      });
+    });
     t.test('setChildren', function (t) {
       t.plan(4);
       var h1 = el.extend('h1');


### PR DESCRIPTION
This pull request addresses the following issue:

Replacing a child element/component _without lifecycle events, or with the last hook for a given event_ with another element (whether it has or does not have lifecycle events doesn't matter) using `setChildren` causes lifecycle events elsewhere in the document to be forgotten.

**RE:DOM version**: 3.12.4

## Steps to trigger behaviour
### Triggering manually:
1. Define a component with `onmount`/`onunmount` lifecycle events
2. Create two instances of the component (henceforth `a` and `b`)
3. Mount instance `a` somewhere
4. Use `setChildren` to assign `a` a child which _does not have lifecycle events_
5. Use `setChildren` to set `b` as `a`'s only child
6. Unmount `a` from its parent

#### Expected behaviour:
`onunmount` is called twice when `a` is unmounted: once on `a`, and once on `b`.

#### Actual behaviour:
`onunmount` is never called.

#### Notes

This can also occur if the child first assigned to `a` has the last hook for a given lifecycle event—when the count is decremented to zero, the traversal will currently assume no more hooks exist as it only checks for the existence of the hooks being removed. See https://jsfiddle.net/1jv9crez/ for an example.

### Triggering using `router`:
1. Create a router with two routes, at least one of which:
    - uses lifecycle events; and
    - sets its children in its `.update` method to at least a child _without lifecycle events_
2. Set the router to the route which meets the above criteria
3. Update the router to the same route (so that it calls update on its current view)
4. Update the router to the as-yet unused route

See https://jsfiddle.net/s072b6xo/ for an example.

#### Expected behaviour:
`onunmount` is called when the router changes from the route with lifecycle events to the other route.

#### Actual behaviour:
`onunmount` is not called.

## Explanation
When setting children using `setChildren`, the new children are mounted and then the old ones are unmounted. During the unmount, whether there are lifecycle hooks is checked using [`if (!hooks) {`](https://github.com/redom/redom/blob/v3.12.4/esm/unmount.js#L25). This correctly detects if no hooks exist in the case where all hooks have previously been removed from the node (in which `hooks === null`). However, when a component or element without lifecycle events is added, for all parents in the tree `hooks` will be an empty object, which evaluates to truthy, causing the unmount to go through the process of decrementing the lifecycle hook count for all parents.

In that process, `doUnmount` determines if there were any hooks remaining on the parent by [iterating through the hooks on the child, decrementing the parent's count for that hook by the child count, and testing if the remaining value is above 0](https://github.com/redom/redom/blob/v3.12.4/esm/unmount.js#L38-L51). There are two ways this can go wrong:
1. if there are no hooks on the child (when `hooks` is an empty object) `hooksFound` can never get set to `true`, so this will always act as though the parent has no hooks, regardless of the contents of `parentHooks`; or
2. if `hooks` contains entries for some but not all events and all of those are reduced to zero in `parentHooks`, `parentHooks` can still contain some entries for the events not contained in `hooks` (e.g., `hooks` is `{ onmount: 1 }` and `parentHooks` is `{ onmount: 1, onunmount: 2 }`), but the values for these will never be checked or taken into account as it only iterates through the keys of `hooks`, so this will act as though the parent has no hooks.

This pull request contains fixes and tests for both of the above cases.