### PR TITLE
Made `util` more performant.

### DIFF
--- a/esm/util.js
+++ b/esm/util.js
@@ -9,7 +9,7 @@ export const parseArguments = (element, args) => {
       continue;
     }
     
-    let type = typeof arg;
+    var type = typeof arg;
 
     // support middleware
     if (type === 'function') {

--- a/esm/util.js
+++ b/esm/util.js
@@ -8,7 +8,7 @@ export const parseArguments = (element, args) => {
     if (arg !== 0 && !arg) {
       continue;
     }
-    
+
     var type = typeof arg;
 
     // support middleware


### PR DESCRIPTION
Removed more than one `typeof el` check in `util`.