### PR TITLE
Removed is* type guard functions

### DIFF
--- a/dist/redom.js
+++ b/dist/redom.js
@@ -273,7 +273,7 @@
 
     if (arg2 !== undefined) {
       el.style[arg1] = arg2;
-    } else if (isString(arg1)) {
+    } else if (typeof arg1 === 'string') {
       el.setAttribute('style', arg1);
     } else {
       for (var key in arg1) {
@@ -290,14 +290,16 @@
     var el = getEl(view);
     var isSVG = el instanceof SVGElement;
 
+    var isFunc = typeof arg2 === 'function';
+
     if (arg2 !== undefined) {
       if (arg1 === 'style') {
         setStyle(el, arg2);
-      } else if (isSVG && isFunction(arg2)) {
+      } else if (isSVG && isFunc) {
         el[arg1] = arg2;
       } else if (arg1 === 'dataset') {
         setData(el, arg2);
-      } else if (!isSVG && (arg1 in el || isFunction(arg2))) {
+      } else if (!isSVG && (arg1 in el || isFunc)) {
         el[arg1] = arg2;
       } else {
         if (isSVG && (arg1 === 'xlink')) {
@@ -354,10 +356,6 @@
 
   var ensureEl = function (parent) { return isString(parent) ? html(parent) : getEl(parent); };
   var getEl = function (parent) { return (parent.nodeType && parent) || (!parent.el && parent) || getEl(parent.el); };
-
-  var isString = function (a) { return typeof a === 'string'; };
-  var isFunction = function (a) { return typeof a === 'function'; };
-
   var isNode = function (a) { return a && a.nodeType; };
 
   var htmlCache = {};
@@ -370,11 +368,13 @@
 
     var element;
 
-    if (isString(query)) {
+    var type = typeof query;
+
+    if (type === 'string') {
       element = memoizeHTML(query).cloneNode(false);
     } else if (isNode(query)) {
       element = query.cloneNode(false);
-    } else if (isFunction(query)) {
+    } else if (type === 'function') {
       var Query = query;
       element = new (Function.prototype.bind.apply( Query, [ null ].concat( args) ));
     } else {
@@ -676,11 +676,13 @@
 
     var element;
 
-    if (isString(query)) {
+    var type = typeof query;
+
+    if (type === 'string') {
       element = memoizeSVG(query).cloneNode(false);
     } else if (isNode(query)) {
       element = query.cloneNode(false);
-    } else if (isFunction(query)) {
+    } else if (type === 'function') {
       var Query = query;
       element = new (Function.prototype.bind.apply( Query, [ null ].concat( args) ));
     } else {

--- a/esm/html.js
+++ b/esm/html.js
@@ -1,5 +1,5 @@
 import { createElement } from './create-element.js';
-import { parseArguments, isString, isNode, isFunction, getEl } from './util.js';
+import { parseArguments, isNode, getEl } from './util.js';
 
 const htmlCache = {};
 
@@ -8,11 +8,13 @@ const memoizeHTML = query => htmlCache[query] || (htmlCache[query] = createEleme
 export const html = (query, ...args) => {
   let element;
 
-  if (isString(query)) {
+  let type = typeof query;
+
+  if (type === 'string') {
     element = memoizeHTML(query).cloneNode(false);
   } else if (isNode(query)) {
     element = query.cloneNode(false);
-  } else if (isFunction(query)) {
+  } else if (type === 'function') {
     const Query = query;
     element = new Query(...args);
   } else {

--- a/esm/listpool.js
+++ b/esm/listpool.js
@@ -1,4 +1,4 @@
-import { isFunction, getEl } from './util.js';
+import { getEl } from './util.js';
 
 const propKey = key => item => item[key];
 
@@ -16,7 +16,7 @@ export class ListPool {
     this.views = [];
 
     if (key != null) {
-      this.key = isFunction(key) ? key : propKey(key);
+      this.key = typeof key === 'function' ? key : propKey(key);
     }
   }
   update (data, context) {

--- a/esm/setattr.js
+++ b/esm/setattr.js
@@ -1,7 +1,7 @@
 /* global SVGElement */
 
 import { setStyle } from './setstyle.js';
-import { isFunction, getEl } from './util.js';
+import { getEl } from './util.js';
 
 const xlinkns = 'http://www.w3.org/1999/xlink';
 
@@ -9,14 +9,16 @@ export const setAttr = (view, arg1, arg2) => {
   const el = getEl(view);
   let isSVG = el instanceof SVGElement;
 
+  let isFunc = typeof arg2 === 'function';
+
   if (arg2 !== undefined) {
     if (arg1 === 'style') {
       setStyle(el, arg2);
-    } else if (isSVG && isFunction(arg2)) {
+    } else if (isSVG && isFunc) {
       el[arg1] = arg2;
     } else if (arg1 === 'dataset') {
       setData(el, arg2);
-    } else if (!isSVG && (arg1 in el || isFunction(arg2))) {
+    } else if (!isSVG && (arg1 in el || isFunc)) {
       el[arg1] = arg2;
     } else {
       if (isSVG && (arg1 === 'xlink')) {

--- a/esm/setstyle.js
+++ b/esm/setstyle.js
@@ -1,11 +1,11 @@
-import { isString, getEl } from './util.js';
+import { getEl } from './util.js';
 
 export const setStyle = (view, arg1, arg2) => {
   const el = getEl(view);
 
   if (arg2 !== undefined) {
     el.style[arg1] = arg2;
-  } else if (isString(arg1)) {
+  } else if (typeof arg1 === 'string') {
     el.setAttribute('style', arg1);
   } else {
     for (const key in arg1) {

--- a/esm/svg.js
+++ b/esm/svg.js
@@ -1,5 +1,5 @@
 import { createElement } from './create-element.js';
-import { parseArguments, isString, isNode, isFunction, getEl } from './util.js';
+import { parseArguments, isNode, getEl } from './util.js';
 
 const ns = 'http://www.w3.org/2000/svg';
 
@@ -10,11 +10,13 @@ const memoizeSVG = query => svgCache[query] || (svgCache[query] = createElement(
 export const svg = (query, ...args) => {
   let element;
 
-  if (isString(query)) {
+  let type = typeof query;
+
+  if (type === 'string') {
     element = memoizeSVG(query).cloneNode(false);
   } else if (isNode(query)) {
     element = query.cloneNode(false);
-  } else if (isFunction(query)) {
+  } else if (type === 'function') {
     const Query = query;
     element = new Query(...args);
   } else {

--- a/esm/util.js
+++ b/esm/util.js
@@ -26,12 +26,7 @@ export const parseArguments = (element, args) => {
   }
 };
 
-export const ensureEl = parent => isString(parent) ? html(parent) : getEl(parent);
+export const ensureEl = parent => typeof parent === 'string' ? html(parent) : getEl(parent);
 export const getEl = parent => (parent.nodeType && parent) || (!parent.el && parent) || getEl(parent.el);
-
-export const isString = a => typeof a === 'string';
-export const isNumber = a => typeof a === 'number';
-export const isFunction = a => typeof a === 'function';
-
 export const isNode = a => a && a.nodeType;
 export const isList = a => a && a.__redom_list;

--- a/test/redom.js
+++ b/test/redom.js
@@ -271,7 +271,7 @@ var setStyle = function (view, arg1, arg2) {
 
   if (arg2 !== undefined) {
     el.style[arg1] = arg2;
-  } else if (isString(arg1)) {
+  } else if (typeof arg1 === 'string') {
     el.setAttribute('style', arg1);
   } else {
     for (var key in arg1) {
@@ -288,14 +288,16 @@ var setAttr = function (view, arg1, arg2) {
   var el = getEl(view);
   var isSVG = el instanceof SVGElement;
 
+  var isFunc = typeof arg2 === 'function';
+
   if (arg2 !== undefined) {
     if (arg1 === 'style') {
       setStyle(el, arg2);
-    } else if (isSVG && isFunction(arg2)) {
+    } else if (isSVG && isFunc) {
       el[arg1] = arg2;
     } else if (arg1 === 'dataset') {
       setData(el, arg2);
-    } else if (!isSVG && (arg1 in el || isFunction(arg2))) {
+    } else if (!isSVG && (arg1 in el || isFunc)) {
       el[arg1] = arg2;
     } else {
       if (isSVG && (arg1 === 'xlink')) {
@@ -350,12 +352,8 @@ var parseArguments = function (element, args) {
   }
 };
 
-var ensureEl = function (parent) { return isString(parent) ? html(parent) : getEl(parent); };
+var ensureEl = function (parent) { return typeof parent === 'string' ? html(parent) : getEl(parent); };
 var getEl = function (parent) { return (parent.nodeType && parent) || (!parent.el && parent) || getEl(parent.el); };
-
-var isString = function (a) { return typeof a === 'string'; };
-var isFunction = function (a) { return typeof a === 'function'; };
-
 var isNode = function (a) { return a && a.nodeType; };
 
 var htmlCache = {};
@@ -368,11 +366,13 @@ var html = function (query) {
 
   var element;
 
-  if (isString(query)) {
+  var type = typeof query;
+
+  if (type === 'string') {
     element = memoizeHTML(query).cloneNode(false);
   } else if (isNode(query)) {
     element = query.cloneNode(false);
-  } else if (isFunction(query)) {
+  } else if (type === 'function') {
     var Query = query;
     element = new (Function.prototype.bind.apply( Query, [ null ].concat( args) ));
   } else {
@@ -472,7 +472,7 @@ var ListPool = function ListPool (View, key, initData) {
   this.views = [];
 
   if (key != null) {
-    this.key = isFunction(key) ? key : propKey(key);
+    this.key = typeof key === 'function' ? key : propKey(key);
   }
 };
 ListPool.prototype.update = function update (data, context) {
@@ -674,11 +674,13 @@ var svg = function (query) {
 
   var element;
 
-  if (isString(query)) {
+  var type = typeof query;
+
+  if (type === 'string') {
     element = memoizeSVG(query).cloneNode(false);
   } else if (isNode(query)) {
     element = query.cloneNode(false);
-  } else if (isFunction(query)) {
+  } else if (type === 'function') {
     var Query = query;
     element = new (Function.prototype.bind.apply( Query, [ null ].concat( args) ));
   } else {


### PR DESCRIPTION
A follow-up to #120, which removes code which checks `typeof x` twice. This should help performance a bit.