### PR TITLE
Added a semistandard ignore deceleration

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,13 @@
   "bugs": {
     "url": "https://github.com/redom/redom/issues"
   },
+  "semistandard": {
+    "ignore": [
+      "/dist/",
+      "/node_modules/",
+      "/test/"
+    ]
+  },
   "homepage": "https://redom.js.org",
   "devDependencies": {
     "browserify": "^16.2.3",


### PR DESCRIPTION
Added a semistandard ignore deceleration in `package.json`, becuase seeing:

```
  /home/def14nt/Desktop/code/Forks/redom/dist/prism.js:6:626: Unexpected use of comma operator.
  /home/def14nt/Desktop/code/Forks/redom/dist/prism.js:6:708: Unnecessary escape character: \/.
  /home/def14nt/Desktop/code/Forks/redom/dist/prism.js:6:734: Unnecessary escape character: \/.
  /home/def14nt/Desktop/code/Forks/redom/dist/prism.js:7:1: Expected an assignment or function call and instead saw an expression.
  /home/def14nt/Desktop/code/Forks/redom/dist/prism.js:7:450: Unnecessary escape character: \?.
  /home/def14nt/Desktop/code/Forks/redom/dist/prism.js:7:452: Unnecessary escape character: \*.
  /home/def14nt/Desktop/code/Forks/redom/dist/prism.js:7:2734: Expected an assignment or function call and instead saw an expression.
  /home/def14nt/Desktop/code/Forks/redom/dist/prism.js:7:2778: Unexpected use of comma operator.
```

on every `semistandard` call is painful.