### PR TITLE
Improved "no need for bundlers" example

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,9 +56,9 @@ el('h1', 'Hello RE:DOM!');
 
       <h3>No need for bundlers</h3>
       <pre><code class="language-html">&lt;script type="module"&gt;
-  import { el } from 'https://redom.js.org/redom.es.min.js';
+  import { el, mount } from 'https://redom.js.org/redom.es.min.js';
 
-  el('h1', 'Hello modules!');
+  mount(document.body, el('h1', 'Hello modules!'));
 &lt;/script&gt;</code></pre>
       <pre><code class="language-markup">&lt;h1&gt;Hello modules!&lt;/h1&gt;</code></pre>
 


### PR DESCRIPTION
The example didn't actually render anything. Adding the mount call means that it does.