### PR TITLE
Correct list component documentation

### DIFF
--- a/dist/doc.md
+++ b/dist/doc.md
@@ -557,7 +557,7 @@ class Tr {
   }
 }
 
-const table = el('table', Tr);
+const table = list('table', Tr);
 
 mount(document.body, table);
 ```
@@ -582,7 +582,7 @@ class Tr {
     this.list.update(data);
   }
 }
-const table = el('table', Tr);
+const table = list('table', Tr);
 
 mount(document.body, table);
 ```


### PR DESCRIPTION
The documentation includes the statements `table = el('table', Tr)` instead of `table = list('table', Tr)` in two cases. This commit corrects that.