### PR TITLE
remove contribute link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npm i redom
 
 ## Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
+This project exists thanks to all the people who contribute.
 <a href="https://github.com/redom/redom/graphs/contributors"><img src="https://opencollective.com/redom/contributors.svg?width=890&button=false" /></a>
 
 


### PR DESCRIPTION
remove contribute link as [Contribute](https://github.com/redom/redom/blob/master/CONTRIBUTING.md) is not a valid link and the file is not located anywhere in redom project anyways.