### PR TITLE
Simplified parseQuery

### DIFF
--- a/esm/parse-query.js
+++ b/esm/parse-query.js
@@ -12,18 +12,14 @@ export function parseQuery (query) {
       if (className.length > 0) {
         className += ' ';
       }
-    }
-    if (char === '#') {
+    } else if (char === '#') {
       isId = true;
       isClass = false;
-    }
-    if (isId && !isClass && char !== '#') {
+    } else if (isId) {
       id += char;
-    }
-    if (isClass && !isId && char !== '.') {
+    } else if (isClass) {
       className += char;
-    }
-    if (!isId && !isClass) {
+    } else {
       tag += char;
     }
   }

--- a/test/redom.js
+++ b/test/redom.js
@@ -16,18 +16,14 @@ function parseQuery (query) {
       if (className.length > 0) {
         className += ' ';
       }
-    }
-    if (char === '#') {
+    } else if (char === '#') {
       isId = true;
       isClass = false;
-    }
-    if (isId && !isClass && char !== '#') {
+    } else if (isId) {
       id += char;
-    }
-    if (isClass && !isId && char !== '.') {
+    } else if (isClass) {
       className += char;
-    }
-    if (!isId && !isClass) {
+    } else {
       tag += char;
     }
   }


### PR DESCRIPTION
When reading the `parseQuery` code I got confused because many checks look unnecessary to me. As far as I can see, it can be simplified to this. Should also be [slightly faster](https://jsperf.com/parsequery/1).