### PR TITLE
[BUGFIX] Fix el fn query argument type and update corresponding return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ export class RedomComponentClass implements RedomComponent {
 
 export type RedomComponentConstructor = RedomComponentClass | RedomComponentFunction;
 export type RedomComponentFactoryFunction = () => RedomComponent
-export type RedomComponentCreator = RedomComponentConstructor | RedomComponentFactoryFunction | Function
+export type RedomComponentCreator = RedomComponentConstructor | RedomComponentFactoryFunction
 
 export class ListPool {
     constructor(View: RedomComponentConstructor, key?: string, initData?: any);
@@ -113,7 +113,6 @@ type RedomElementOfElQuery<Q extends RedomElQuery> =
     Q extends RedomComponentFunction ? InstanceType<Q>:
     Q extends RedomComponentClass ? Q:
     Q extends RedomComponentFactoryFunction ? ReturnType<Q>:
-    Q extends Function ? HTMLElement:
     Q extends string ? HTMLElementOfStringLiteral<Q>:
     never
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ export type RedomQuery = string | RedomElement;
 export type RedomMiddleware = (el: HTMLElement) => void;
 export type RedomQueryArgumentValue = RedomElement | string | number | { [key: string]: any } | RedomMiddleware;
 export type RedomQueryArgument = RedomQueryArgumentValue | RedomQueryArgumentValue[];
+export type RedomElQuery = string | Node | RedomComponentCreator;
 
 export interface RedomComponent {
     el: HTMLElement;
@@ -32,6 +33,8 @@ export class RedomComponentClass implements RedomComponent {
 }
 
 export type RedomComponentConstructor = RedomComponentClass | RedomComponentFunction;
+export type RedomComponentFactoryFunction = () => RedomComponent
+export type RedomComponentCreator = RedomComponentConstructor | RedomComponentFactoryFunction | Function
 
 export class ListPool {
     constructor(View: RedomComponentConstructor, key?: string, initData?: any);
@@ -105,14 +108,18 @@ type HTMLElementOfStringLiteral<Q extends string> =
     Q extends 'svg' ? SVGElement:
     HTMLElement
 
-type HTMLElementOfRedomQuery<Q extends RedomQuery> =
-    Q extends RedomElement ? Q:
+type RedomElementOfElQuery<Q extends RedomElQuery> =
+    Q extends Node ? Q:
+    Q extends RedomComponentFunction ? InstanceType<Q>:
+    Q extends RedomComponentClass ? Q:
+    Q extends RedomComponentFactoryFunction ? ReturnType<Q>:
+    Q extends Function ? HTMLElement:
     Q extends string ? HTMLElementOfStringLiteral<Q>:
     never
 
-export function html<Q extends RedomQuery>(query: Q, ...args: RedomQueryArgument[]): HTMLElementOfRedomQuery<Q>;
-export function h<Q extends RedomQuery>(query: Q, ...args: RedomQueryArgument[]): HTMLElementOfRedomQuery<Q>;
-export function el<Q extends RedomQuery>(query: Q, ...args: RedomQueryArgument[]): HTMLElementOfRedomQuery<Q>;
+export function html<Q extends RedomElQuery>(query: Q, ...args: RedomQueryArgument[]): RedomElementOfElQuery<Q>;
+export function h<Q extends RedomElQuery>(query: Q, ...args: RedomQueryArgument[]): RedomElementOfElQuery<Q>;
+export function el<Q extends RedomElQuery>(query: Q, ...args: RedomQueryArgument[]): RedomElementOfElQuery<Q>;
 
 export function listPool(View: RedomComponentConstructor, key?: string, initData?: any): ListPool;
 export function list(parent: RedomQuery, View: RedomComponentConstructor, key?: string, initData?: any): List;


### PR DESCRIPTION
This is how typescript resolves the types on this pr:
![redomElTypes](https://user-images.githubusercontent.com/4012401/60052123-ce4e9380-96d4-11e9-8590-3b364683d466.png)

~The only one case not having a nice element resolution is the `aEl`. Reason is, because the this.el definition in the function cannot be recognized by typescript, I previously decided to just fallback to HTMLElement in this case, but I think we should actually change this case to RedomComponent.~

Edit: we removed Function as a valid query argument type so the aEl case has to be typed by the consumer manually.

---

Used code for type testing:
```typescript
import { el } from '.'

class TdComponent {
    el = el('td')
}

const els = {
    tableEl: el(document.createElement('table')),
    tdComponent: el(TdComponent),
    divEl: el('div'),
    aEl: el(function() {
        this.el = el('a')
    }),
    buttonEl: el(function() {
        return {
            el: el('button')
        } 
    }),
    inputEl: el('input')
}
``` 