### PR TITLE
Add additional type definition for mount

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -152,6 +152,7 @@ export function el<Q extends RedomElQuery>(query: Q, ...args: RedomQueryArgument
 export function listPool(View: RedomComponentConstructor, key?: string, initData?: any): ListPool;
 export function list(parent: RedomQuery, View: RedomComponentConstructor, key?: string, initData?: any): List;
 
+export function mount<T extends HTMLElement>(parent: RedomElement, child: T, before?: RedomElement, replace?: boolean): T;
 export function mount(parent: RedomElement, child: RedomElement, before?: RedomElement, replace?: boolean): RedomElement;
 export function unmount(parent: RedomElement, child: RedomElement): RedomElement;
 


### PR DESCRIPTION
I'm in the process of reverse-engineering a project built using RE:DOM, and noticed they assumed the `mount` method always returns the child element passed, if said child is a `HTMLElement`. After reading through the RE:DOM source code, I confirmed that this assumption was correct.

I have added an overload to the `mount` method in the type definitions file.